### PR TITLE
Allow both `main` and `docs` branches for action

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -18,6 +18,7 @@ jobs:
         path: docs/build/html/
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs'}}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build/html


### PR DESCRIPTION
* Specify both `main` and `docs` as valid branches within which to run the Github Action to publish documentation.