### PR TITLE
Allow documentation updates on push

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,6 +1,10 @@
-name: "Sphinx: Render docs"
+name: "Sphinx: Render Documentation"
 
-on: workflow_dispatch
+on:
+    workflow_dispatch:
+    push:
+        branches:
+            - docs
 
 jobs:
   build:
@@ -18,7 +22,7 @@ jobs:
         path: docs/build/html/
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs'}}
+      if: ${{github.ref == 'refs/heads/docs'}}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build/html


### PR DESCRIPTION
* Github pushes to the docs branch will now trigger Sphinx rendering.
* Manual updates are still allowed.