### PR TITLE
Add reloads to contextual menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Installing and Running
 The source code can be downloaded from the AXMAS Git repository:
 
 ```
-    $ git clone https://github.com/axmas-anl/nxrefine.git
+    $ git clone https://github.com/nexpy/nxrefine.git
 ```
 
 To install in the standard Python location:
@@ -72,5 +72,5 @@ User Support
 ============
 If you are interested in using this package, please contact Ray Osborn 
 (ROsborn@anl.gov). Please report any bugs as a 
-[Github issue](https://github.com/axmas/nxrefine/issues), with relevant 
+[Github issue](https://github.com/nexpy/nxrefine/issues), with relevant 
 tracebacks.

--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -259,6 +259,7 @@ class NXReduce(QtCore.QObject):
 
     def __enter__(self):
         self._mode = self.root.nxfilemode
+        self.root.reload()
         self.root.unlock()
         return self.root.__enter__()
 

--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -225,6 +225,7 @@ class NXRefine:
         if self.entry is None:
             raise NeXusError('NXRefine entry not defined')
         self._mode = self.root.nxfilemode
+        self.root.reload()
         self.root.unlock()
         return self.root.__enter__()
 


### PR DESCRIPTION
* Forces the root to reload when locking the file for writing in both the NXReduce and NXRefine classes. This currently fails if the file has been modified since first being opened.