### PR TITLE
Fix-concurrent-memory

### DIFF
--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -2139,11 +2139,11 @@ class NXMultiReduce(NXReduce):
         symm_root['entry/data'].nxsignal = symm_root['entry/data/data']
         symm_root['entry/data'].nxweights = 1.0 / self.taper
         symm_root['entry/data'].nxaxes = self.entry[self.transform_path].nxaxes
-        if self.symm_data in self.entry:
-            del self.entry[self.symm_data]
-        symm_data = NXlink('/entry/data/data', file=self.symm_file,
-                           name='data')
         with self:
+            if self.symm_data in self.entry:
+                del self.entry[self.symm_data]
+            symm_data = NXlink('/entry/data/data', file=self.symm_file,
+                               name='data')
             self.entry[self.symm_data] = NXdata(
                 symm_data, self.entry[self.transform_path].nxaxes)
             self.entry[self.symm_data].nxweights = NXlink(

--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -2255,7 +2255,8 @@ class NXMultiReduce(NXReduce):
 
     @property
     def indices(self):
-        self.refine.polar_max = self.refine.two_theta_max()
+        self.refine.polar_max = max([NXRefine(self.root[e]).two_theta_max()
+                                     for e in self.entries])
         if self.refine.laue_group in ['-3', '-3m', '6/m', '6/mmm']:
             _indices = []
             for idx in self.refine.indices:
@@ -2297,7 +2298,8 @@ class NXMultiReduce(NXReduce):
         mk = int((mask.shape[1]-1)/2)
         mh = int((mask.shape[2]-1)/2)
         fill_data = np.zeros(shape=symm_data.shape, dtype=symm_data.dtype)
-        self.refine.polar_max = self.refine.two_theta_max()
+        self.refine.polar_max = max([NXRefine(self.root[e]).two_theta_max()
+                                     for e in self.entries])
         for h, k, l in self.indices:
             try:
                 ih = np.argwhere(np.isclose(Qh, h))[0][0]

--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -1330,9 +1330,9 @@ class NXReduce(QtCore.QObject):
         tic = self.start_progress(self.first, self.last)
         self.blobs = []
         if self.server.concurrent:
-            from concurrent.futures import ProcessPoolExecutor, as_completed
-            with ProcessPoolExecutor(
-                    max_workers=self.process_count) as executor:
+            from nxrefine.nxutils import NXExecutor, as_completed
+            from multiprocessing import get_context
+            with NXExecutor(max_workers=self.process_count) as executor:
                 futures = []
                 for i in range(self.first, self.last+1, 50):
                     j, k = i - min(5, i), min(i+55, self.last+5, self.nframes)
@@ -1482,9 +1482,8 @@ class NXReduce(QtCore.QObject):
             NXfield(shape=self.shape, dtype=np.int8, fillvalue=0))
 
         if self.server.concurrent:
-            from concurrent.futures import ProcessPoolExecutor, as_completed
-            with ProcessPoolExecutor(
-                    max_workers=self.process_count) as executor:
+            from nxrefine.nxutils import NXExecutor, as_completed
+            with NXExecutor(max_workers=self.process_count) as executor:
                 futures = []
                 for i in range(self.first, self.last+1, 10):
                     j, k = i - min(1, i), min(i+11, self.last+1, self.nframes)

--- a/src/nxrefine/nxsymmetry.py
+++ b/src/nxrefine/nxsymmetry.py
@@ -10,7 +10,8 @@ import tempfile
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import numpy as np
-from nexusformat.nexus import nxload, nxsetlock
+
+from .nxutils import NXExecutor, as_completed
 
 
 def triclinic(data):
@@ -144,7 +145,7 @@ class NXSymmetry:
             symmetrize = symmetrize_entries
         else:
             symmetrize = symmetrize_data
-        with ProcessPoolExecutor(max_workers=2) as executor:
+        with NXExecutor(max_workers=2) as executor:
             futures = []
             for data_type in ['signal', 'weights']:
                 futures.append(executor.submit(

--- a/src/nxrefine/nxsymmetry.py
+++ b/src/nxrefine/nxsymmetry.py
@@ -7,9 +7,9 @@
 # -----------------------------------------------------------------------------
 import os
 import tempfile
-from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import numpy as np
+from nexusformat.nexus import nxopen, nxsetconfig
 
 from .nxutils import NXExecutor, as_completed
 
@@ -78,42 +78,47 @@ def cubic(data):
 
 
 def symmetrize_entries(symm_function, data_type, data_file, data_path):
-    nxsetlock(60)
-    data_root = nxload(data_file, 'r')
-    data_path = os.path.basename(data_path)
-    for i, entry in enumerate([e for e in data_root if e[-1].isdigit()]):
-        if i == 0:
-            if data_type == 'signal':
-                data = data_root[entry][data_path].nxsignal.nxvalue
-            elif data_root[entry][data_path].nxweights:
-                data = data_root[entry][data_path].nxweights.nxvalue
+    nxsetconfig(lock=3600, lockexpiry=28800)
+    with nxopen(data_file, 'r') as data_root:
+        data_path = os.path.basename(data_path)
+        for i, entry in enumerate([e for e in data_root if e[-1].isdigit()]):
+            data_size = int(
+                data_root[entry][data_path].nxsignal.nbytes / 1e6) + 1000
+            nxsetconfig(memory=data_size)
+            if i == 0:
+                if data_type == 'signal':
+                    data = data_root[entry][data_path].nxsignal.nxvalue
+                elif data_root[entry][data_path].nxweights:
+                    data = data_root[entry][data_path].nxweights.nxvalue
+                else:
+                    signal = data_root[entry][data_path].nxsignal.nxvalue
+                    data = np.zeros(signal.shape, dtype=signal.dtype)
+                    data[np.where(signal > 0)] = 1
             else:
-                signal = data_root[entry][data_path].nxsignal.nxvalue
-                data = np.zeros(signal.shape, dtype=signal.dtype)
-                data[np.where(signal > 0)] = 1
-        else:
-            if data_type == 'signal':
-                data += data_root[entry][data_path].nxsignal.nxvalue
-            elif data_root[entry][data_path].nxweights:
-                data += data_root[entry][data_path].nxweights.nxvalue
+                if data_type == 'signal':
+                    data += data_root[entry][data_path].nxsignal.nxvalue
+                elif data_root[entry][data_path].nxweights:
+                    data += data_root[entry][data_path].nxweights.nxvalue
     result = symm_function(data)
-    root = nxload(tempfile.mkstemp(suffix='.nxs')[1], mode='w')
-    root['data'] = result
+    with nxopen(tempfile.mkstemp(suffix='.nxs')[1], mode='w') as root:
+        root['data'] = result
     return data_type, root.nxfilename
 
 
 def symmetrize_data(symm_function, data_type, data_file, data_path):
-    nxsetlock(60)
-    data_root = nxload(data_file, 'r')
-    if data_type == 'signal':
-        data = data_root[data_path].nxvalue
-    else:
-        signal = data_root[data_path].nxvalue
-        data = np.zeros(signal.shape, signal.dtype)
-        data[np.where(signal > 0)] = 1
+    nxsetconfig(lock=3600, lockexpiry=28800)
+    with nxopen(data_file, 'r') as data_root:
+        data_size = int(data_root[data_path].nbytes / 1e6) + 1000
+        nxsetconfig(memory=data_size)
+        if data_type == 'signal':
+            data = data_root[data_path].nxvalue
+        else:
+            signal = data_root[data_path].nxvalue
+            data = np.zeros(signal.shape, signal.dtype)
+            data[np.where(signal > 0)] = 1
     result = symm_function(data)
-    root = nxload(tempfile.mkstemp(suffix='.nxs')[1], mode='w')
-    root['data'] = result
+    with nxopen(tempfile.mkstemp(suffix='.nxs')[1], mode='w') as root:
+        root['data'] = result
     return data_type, root.nxfilename
 
 
@@ -153,11 +158,11 @@ class NXSymmetry:
                     self.data_file, self.data_path))
         for future in as_completed(futures):
             data_type, result_file = future.result()
-            result_root = nxload(result_file, 'r')
-            if data_type == 'signal':
-                signal = result_root['data'].nxvalue
-            else:
-                weights = result_root['data'].nxvalue
+            with nxopen(result_file, 'r') as result_root:
+                if data_type == 'signal':
+                    signal = result_root['data'].nxvalue
+                else:
+                    weights = result_root['data'].nxvalue
             os.remove(result_file)
         with np.errstate(divide='ignore', invalid='ignore'):
             result = np.where(weights > 0, signal / weights, 0.0)

--- a/src/nxrefine/nxutils.py
+++ b/src/nxrefine/nxutils.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING, distributed with this software.
 # -----------------------------------------------------------------------------
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from multiprocessing import get_context
 import numpy as np
 from nexusformat.nexus import (NXdata, NXentry, NXfield, NXlog, NXroot, nxopen,
                                nxsetconfig)
@@ -589,3 +591,14 @@ class SpecParser:
         for subkey, value in spec_metadata.items():
             nxlog[subkey] = NXfield(value)
         return nxlog
+
+
+class NXExecutor(ProcessPoolExecutor):
+    """ProcessPoolExecutor class using 'spawn' for new processes."""
+
+    def __init__(self, max_workers=None):
+        mp_context = get_context('spawn')
+        super().__init__(max_workers=max_workers, mp_context=mp_context)
+
+    def __repr__(self):
+        return f"NXExecutor(max_workers={self._max_workers})"


### PR DESCRIPTION
* Adds a subclass to ProcessPoolExecutor to automatically set the context to spawn subprocesses. This should reduce the allocated memory.
* Improves use of contextual menus to reduce lockfile exceptions in multiple processes.
* Improves the calculation of polar_max with multiple entries.