### PR TITLE
Use old orientation in initializing NXRefine

### DIFF
--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -163,7 +163,7 @@ class NXRefine:
         self.gamma = 90.0
         self.wavelength = 1.0
         self.distance = 100.0
-        self.detector_orientation = '-y -z +x'
+        self.detector_orientation = '-y +z -x' #Old default orientation
         self._yaw = 0.0
         self._pitch = 0.0
         self._roll = 0.0

--- a/src/nxrefine/nxsettings.py
+++ b/src/nxrefine/nxsettings.py
@@ -25,7 +25,7 @@ class NXSettings(ConfigParser):
                            'raw_home': None, 'raw_path': None,
                            'analysis_home': None, 'analysis_path': None},
             'nxrefine': {'wavelength': 0.2, 'distance': 500,
-                         'detector_orientation': '-y -z +x',
+                         'detector_orientation': '-y +z -x',
                          'phi': -5.0, 'phi_end': 360.0, 'phi_step': 0.1,
                          'chi': 0.0, 'omega': 0.0, 'theta': 0.0,
                          'x': 0.0, 'y': 0.0,


### PR DESCRIPTION
* If there is no detector orientation stored in the
NeXus file, NXRefine will use the previous default.