### PR TITLE
Return a monitor weight of 1 if no monitor is defined.

### DIFF
--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -1284,17 +1284,20 @@ class NXReduce(QtCore.QObject):
         return min_mask | max_mask
 
     def read_monitor(self):
-        from scipy.signal import savgol_filter
-        monitor_signal = self.entry[self.monitor].nxsignal / self.norm
-        monitor_signal[0] = monitor_signal[1]
-        monitor_signal[-1] = monitor_signal[-2]
-        if monitor_signal.size > 1000:
-            filter_size = 501
-        elif monitor_signal.size > 200:
-            filter_size = 101
-        else:
-            filter_size = monitor_signal.size
-        return savgol_filter(monitor_signal, filter_size, 2)
+        try:
+            from scipy.signal import savgol_filter
+            monitor_signal = self.entry[self.monitor].nxsignal / self.norm
+            monitor_signal[0] = monitor_signal[1]
+            monitor_signal[-1] = monitor_signal[-2]
+            if monitor_signal.size > 1000:
+                filter_size = 501
+            elif monitor_signal.size > 200:
+                filter_size = 101
+            else:
+                filter_size = monitor_signal.size
+            return savgol_filter(monitor_signal, filter_size, 2)
+        except Exception:
+            return np.ones(shape=(self.nframes))
 
     def nxfind(self):
         if self.not_processed('nxfind') and self.find:


### PR DESCRIPTION
* If a monitor has not been properly defined on an instrument, the `read_monitor` function returns an array of ones. In defined, the sample transmission is corrected for the monitor. If not, the sample transmission will implicitly include a monitor correction. 