### PR TITLE
Use-detector-orientation

### DIFF
--- a/src/nxrefine/nxutils.py
+++ b/src/nxrefine/nxutils.py
@@ -403,7 +403,7 @@ def detector_flipped(entry):
     """    
     if 'detector_orientation' in entry['instrument/detector']:
         omat = np.array(parse_orientation(
-            self.entry['instrument/detector/detector_orientation']))
+            entry['instrument/detector/detector_orientation']))
         if omat[1][2] == -1:
             return True
         else:

--- a/src/nxrefine/nxutils.py
+++ b/src/nxrefine/nxutils.py
@@ -341,7 +341,7 @@ def parse_orientation(orientation):
 
     Parameters
     ----------
-    orientation : str or array_like
+    orientation : NXfield, str or array_like
         The description of the orientation as a string or a 3x3 array. 
 
     Returns
@@ -355,6 +355,8 @@ def parse_orientation(orientation):
         Invalid input value describing the orientation.
     """    
     try:
+        if isinstance(orientation, NXfield):
+            orientation = orientation.nxvalue
         if isinstance(orientation, str):
             _omat = np.zeros((3, 3), dtype=int)
             i = 0
@@ -374,6 +376,40 @@ def parse_orientation(orientation):
             return np.matrix(orientation)
     except Exception:
         raise NeXusError('Invalid detector orientation')
+
+
+def detector_flipped(entry):
+    """Return True if the y-axis is flipped.
+    
+    If images from the detector have their origin in the top-left
+    corner, their y-axis needs to be flipped in order to view the
+    physical geometry of the detector.
+    
+    Note
+    ----
+    The detector orientation has only recently been specified in the
+    NXRefine module. Before this, all the images were assumed to be
+    flipped.
+
+    Parameters
+    ----------
+    entry : NXentry
+        The NeXus entry group containing the detector information
+
+    Returns
+    -------
+    bool
+        True if the detector is flipped along the y-axis.
+    """    
+    if 'detector_orientation' in entry['instrument/detector']:
+        omat = np.array(parse_orientation(
+            self.entry['instrument/detector/detector_orientation']))
+        if omat[1][2] == -1:
+            return True
+        else:
+            return False
+    else:
+        return True
 
 
 class SpecParser:

--- a/src/nxrefine/plugins/experiment/calibrate_powder.py
+++ b/src/nxrefine/plugins/experiment/calibrate_powder.py
@@ -21,6 +21,8 @@ from pyFAI.calibrant import ALL_CALIBRANTS
 from pyFAI.geometryRefinement import GeometryRefinement
 from pyFAI.massif import Massif
 
+from nxrefine.nxutils import detector_flipped
+
 
 def show_dialog():
     try:
@@ -166,7 +168,7 @@ class CalibrateDialog(NXDialog):
     def plot_data(self):
         self.pv.plot(self.data, log=True)
         self.pv.aspect = 'equal'
-        self.pv.ytab.flipped = True
+        self.pv.ytab.flipped = detector_flipped(self.entry)
         self.clear_points()
 
     def on_button_press(self, event):

--- a/src/nxrefine/plugins/experiment/create_mask.py
+++ b/src/nxrefine/plugins/experiment/create_mask.py
@@ -15,6 +15,8 @@ from nexpy.gui.utils import load_image, report_error
 from nexpy.gui.widgets import NXcircle, NXrectangle
 from nexusformat.nexus import NeXusError, NXdata, NXfield
 
+from nxrefine.nxutils import detector_flipped
+
 
 def show_dialog():
     try:
@@ -103,7 +105,7 @@ class MaskDialog(NXDialog):
             self.pv.plot(NXdata(self.mask, axes=self.data.nxaxes,
                                 title=self.title))
         self.pv.aspect = 'equal'
-        self.pv.ytab.flipped = True
+        self.pv.ytab.flipped = detector_flipped(self.entry)
         self.pv.draw()
 
     def plot_limits(self):

--- a/src/nxrefine/plugins/refine/find_maximum.py
+++ b/src/nxrefine/plugins/refine/find_maximum.py
@@ -15,7 +15,9 @@ from nexpy.gui.utils import (confirm_action, display_message, is_file_locked,
 from nexpy.gui.widgets import NXCheckBox, NXLabel
 from nexusformat.nexus import (NeXusError, NXdata, NXfield, NXinstrument,
                                NXsample)
+
 from nxrefine.nxreduce import NXReduce
+from nxrefine.nxutils import detector_flipped
 
 
 def show_dialog():
@@ -215,7 +217,7 @@ class MaximumDialog(NXDialog):
                                          name='x')),
                                 title='Summed Data'), log=True)
             self.pv.aspect = 'equal'
-            self.pv.ytab.flipped = True
+            self.pv.ytab.flipped = detector_flipped(self.entry)
         else:
             display_message('Summed_data not available')
 
@@ -257,7 +259,7 @@ class MaximumDialog(NXDialog):
                                      name='x')),
                             title='Transmission Mask'))
         self.pv.aspect = 'equal'
-        self.pv.ytab.flipped = True
+        self.pv.ytab.flipped = detector_flipped(self.entry)
 
     def calculate_transmission(self):
         self.reduce.partial_frames = self.partial_frames


### PR DESCRIPTION
* Defines a new utility function for determining if the y-axis of detector images should be flipped.
* Uses the new function in the "Calibrate Powder", "Create Mask", and "Find Maximum" dialogs.
