### PR TITLE
Fix-polar-max-setting

### DIFF
--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -403,11 +403,11 @@ class NXRefine:
                 'instrument/detector/orientation_matrix')
             if isinstance(self.polar_angle, np.ndarray):
                 try:
-                    self.polar_max = np.sort(self.polar_angle)[200] + 0.1
+                    self._polar_max = np.sort(self.polar_angle)[200] + 0.1
                 except IndexError:
-                    self.polar_max = self.polar_angle.max()
+                    self._polar_max = self.polar_angle.max()
             else:
-                self.polar_max = 10.0
+                self._polar_max = 10.0
             self.Qh = self.read_parameter('transform/Qh')
             self.Qk = self.read_parameter('transform/Qk')
             self.Ql = self.read_parameter('transform/Ql')
@@ -1619,12 +1619,13 @@ class NXRefine:
     def initialize_idx(self, hkl_tolerance=None):
         """Define the peaks whose positions are within the HKL tolerance."""
         self._idx = ma.arange(self.npks, dtype=int)
-        self._idx[self.polar_angle>self.polar_max] = ma.masked
-        if hkl_tolerance is not None:
-            self.hkl_tolerance = hkl_tolerance
-        mask = [i for i in self._idx.compressed()
-                if self.diff(i) > self.hkl_tolerance]
-        self._idx[mask] = ma.masked
+        if self.polar_angle is not None:
+            self._idx[self.polar_angle>self.polar_max] = ma.masked
+            if hkl_tolerance is not None:
+                self._hkl_tolerance = hkl_tolerance
+            mask = [i for i in self._idx.compressed()
+                    if self.diff(i) > self.hkl_tolerance]
+            self._idx[mask] = ma.masked
 
     @property
     def weights(self):

--- a/src/nxrefine/plugins/refine/refine_lattice.py
+++ b/src/nxrefine/plugins/refine/refine_lattice.py
@@ -565,7 +565,7 @@ class RefineLatticeDialog(NXDialog):
         self.peaks_box = NXDialog(self)
         self.peaks_box.setMinimumWidth(600)
         self.peaks_box.setMinimumHeight(600)
-        header = ['i', 'x', 'y', 'z', 'Polar', 'Azi', 'Intensity',
+        header = ['Peak', 'x', 'y', 'z', 'Polar', 'Azi', 'Intensity',
                   'H', 'K', 'L', 'Diff']
         peak_list = self.refine.get_peaks()
         self.refine.assign_rings()
@@ -589,9 +589,6 @@ class RefineLatticeDialog(NXDialog):
         self.table_model = NXTableModel(self, peak_list, header)
         self.table_view.setModel(self.table_model)
         self.table_view.resizeColumnsToContents()
-        self.table_view.horizontalHeader().resizeSections(
-            QtWidgets.QHeaderView.ResizeToContents)
-        self.table_view.setMinimumWidth(570)
         self.table_view.setSelectionBehavior(
             QtWidgets.QAbstractItemView.SelectRows)
         self.table_view.doubleClicked.connect(self.plot_peak)
@@ -613,6 +610,7 @@ class RefineLatticeDialog(NXDialog):
         self.peaks_box.set_layout(orient_layout, self.table_view, close_layout)
         self.peaks_box.set_title(f'{self.refine.name} Peak Table')
         self.peaks_box.adjustSize()
+        self.peaks_box.setMinimumWidth(self.peaks_box.width()+10)
         self.peaks_box.show()
         self.peakview = None
         self.report_score()


### PR DESCRIPTION
* Fixes a bug when defining peak masks before the polar angles have been read.
* Tweaks the size of the peak list window.