### PR TITLE
Customize-beamline-monitor

### DIFF
--- a/src/nxrefine/nxbeamline.py
+++ b/src/nxrefine/nxbeamline.py
@@ -37,7 +37,31 @@ def import_beamlines():
             pass
 
 
+def get_beamlines():
+    """Return a list of available beamline names
+
+    Returns
+    -------
+    list of str
+        Names of beamlines defined by NXBeamLine subclasses
+    """    
+    return [beamline.name for beamline in NXBeamLine.__subclasses__()]
+
+
 def get_beamline(instrument=None):
+    """Return subclass of NXBeamLine for a particular instrument
+
+    Parameters
+    ----------
+    instrument : str, optional
+        Name of the instrument, by default None. If not specified, the
+        instrument defined by the default server settings is used.
+
+    Returns
+    -------
+    NXBeamLine
+        Subclass of NXBeamLine for the requested instrument
+    """    
     if instrument is None:
         instrument = NXSettings().settings['instrument']['instrument']
     if instrument == '':

--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -346,7 +346,7 @@ class NXReduce(QtCore.QObject):
         """NXBeamLine class for importing data and logs."""
         if self._beamline is None:
             instrument = self.settings['instrument']['instrument']
-            self._beamline = get_beamline(instrument=instrument)(self)
+            self._beamline = get_beamline(instrument=instrument)(reduce=self)
         return self._beamline
 
     @property
@@ -552,7 +552,7 @@ class NXReduce(QtCore.QObject):
             field_name = name
         if (self.parent and 'nxreduce' in self.parent_root['entry']
                 and field_name in self.parent_root['entry/nxreduce']):
-            parameter = self.parent_root['entry/nxreduce'][field_name]
+            parameter = self.parent_root['entry/nxreduce'][field_name].nxvalue
         elif ('nxreduce' in self.root['entry']
               and field_name in self.root['entry/nxreduce']):
             parameter = self.root['entry/nxreduce'][field_name].nxvalue
@@ -1287,19 +1287,9 @@ class NXReduce(QtCore.QObject):
 
     def read_monitor(self):
         try:
-            from scipy.signal import savgol_filter
-            monitor_signal = self.entry[self.monitor].nxsignal / self.norm
-            monitor_signal[0] = monitor_signal[1]
-            monitor_signal[-1] = monitor_signal[-2]
-            if monitor_signal.size > 1000:
-                filter_size = 501
-            elif monitor_signal.size > 200:
-                filter_size = 101
-            else:
-                filter_size = monitor_signal.size
-            return savgol_filter(monitor_signal, filter_size, 2)
+            return self.beamline.read_monitor(self.monitor)
         except Exception:
-            return np.ones(shape=(self.nframes))
+            return np.ones(shape=(self.nframes), dtype=float)
 
     def nxfind(self):
         if self.not_processed('nxfind') and self.find:

--- a/src/nxrefine/plugins/experiment/edit_settings.py
+++ b/src/nxrefine/plugins/experiment/edit_settings.py
@@ -10,10 +10,11 @@ import os
 from pathlib import Path
 
 from nexpy.gui.datadialogs import GridParameters, NXDialog
-from nexpy.gui.utils import report_error
+from nexpy.gui.utils import display_message, report_error
 from nexpy.gui.widgets import NXLabel, NXPushButton, NXScrollArea
 from nexusformat.nexus import NeXusError
 
+from nxrefine.nxbeamline import get_beamlines
 from nxrefine.nxsettings import NXSettings
 
 
@@ -41,6 +42,8 @@ class ExperimentSettingsDialog(NXDialog):
             defaults['experiment'] = ''
         for p in defaults:
             self.instrument_parameters.add(p, defaults[p], p)
+        self.instrument_parameters['instrument'].box.editingFinished.connect(
+            self.check_beamline)
         self.refine_parameters = GridParameters()
         defaults = settings['nxrefine']
         for p in defaults:
@@ -119,6 +122,13 @@ class ExperimentSettingsDialog(NXDialog):
         self.raise_()
         self.activateWindow()
         self.setFocus()
+
+    def check_beamline(self):
+        beamlines = get_beamlines()
+        if self.instrument_parameters['instrument'].value not in beamlines:
+            display_message("Beamline Not Supported",
+                            "Supported beamlines are: "
+                            f"{', '.join(str(i) for i in get_beamlines())}")
 
     def accept(self):
         try:

--- a/src/nxrefine/plugins/experiment/new_configuration.py
+++ b/src/nxrefine/plugins/experiment/new_configuration.py
@@ -130,7 +130,7 @@ class ConfigurationDialog(NXDialog):
                           'Maximum Polar Angle')
         self.analysis.add('hkl_tolerance', entry['nxreduce/hkl_tolerance'],
                           'HKL Tolerance (Å-1)')
-        self.analysis.add('monitor', ['monitor1', 'monitor2'],
+        self.analysis.add('monitor', entry['nxreduce/monitor'],
                           'Normalization Monitor')
         self.analysis['monitor'].value = default['monitor']
         self.analysis.add('norm', entry['nxreduce/norm'],

--- a/src/nxrefine/plugins/refine/choose_parameters.py
+++ b/src/nxrefine/plugins/refine/choose_parameters.py
@@ -38,7 +38,7 @@ class ParametersDialog(NXDialog):
                             'Max. Polar Angle')
         self.parameters.add('hkl_tolerance', default['hkl_tolerance'],
                             'HKL Tolerance (Å-1)')
-        self.parameters.add('monitor', ['monitor1', 'monitor2'],
+        self.parameters.add('monitor', default['monitor'],
                             'Normalization Monitor')
         self.parameters['monitor'].value = default['monitor']
         self.parameters.add('norm', default['norm'], 'Normalization Value')

--- a/src/nxrefine/plugins/server/edit_settings.py
+++ b/src/nxrefine/plugins/server/edit_settings.py
@@ -10,10 +10,11 @@ import os
 from pathlib import Path
 
 from nexpy.gui.datadialogs import GridParameters, NXDialog
-from nexpy.gui.utils import report_error
+from nexpy.gui.utils import display_message, report_error
 from nexpy.gui.widgets import NXScrollArea
 from nexusformat.nexus import NeXusError
 
+from nxrefine.nxbeamline import get_beamlines
 from nxrefine.nxsettings import NXSettings
 
 
@@ -38,6 +39,8 @@ class ServerSettingsDialog(NXDialog):
         defaults = self.settings.settings['instrument']
         for p in defaults:
             self.instrument_parameters.add(p, defaults[p], p)
+        self.instrument_parameters['instrument'].box.editingFinished.connect(
+            self.check_beamline)
         self.refine_parameters = GridParameters()
         defaults = self.settings.settings['nxrefine']
         for p in defaults:
@@ -57,6 +60,13 @@ class ServerSettingsDialog(NXDialog):
                         self.close_layout(save=True))
         self.setMinimumWidth(300)
         self.set_title('Edit Settings')
+
+    def check_beamline(self):
+        beamlines = get_beamlines()
+        if self.instrument_parameters['instrument'].value not in beamlines:
+            display_message("Beamline Not Supported",
+                            "Supported beamlines are: "
+                            f"{', '.join(str(i) for i in get_beamlines())}")
 
     def accept(self):
         try:


### PR DESCRIPTION
* Gives greater flexibility in choosing monitor arrays stored in beamline logs.
* Removes hard-wiring of monitor names for essential operations.