### PR TITLE
Add-async-option

### DIFF
--- a/src/nxrefine/nxlogger.py
+++ b/src/nxrefine/nxlogger.py
@@ -50,7 +50,7 @@ class LogRecordStreamHandler(StreamRequestHandler):
             name = record.name
         logger = logging.getLogger(name)
         if not logger.hasHandlers():
-            handler = logging.FileHandler(self.server.log_file)
+            handler = logging.FileHandler(self.server.server_log)
             formatter = logging.Formatter(
                             '%(asctime)s %(name)-12s: %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S')

--- a/src/nxrefine/plugins/server/manage_workflows.py
+++ b/src/nxrefine/plugins/server/manage_workflows.py
@@ -569,7 +569,7 @@ class WorkflowDialog(NXDialog):
         self.defaultview = self.serverview
         scan = os.path.join(self.sample, self.label,
                             self.scan_combo.currentText())
-        with open(self.server.log_file) as f:
+        with open(self.server.server_log) as f:
             lines = f.readlines()
         text = [line for line in lines if scan in line]
         if text:


### PR DESCRIPTION
* If `server_type` is set to None, calls to `add_task` are executed directly in a worker thread.
* This removes the need for the file-based queue in systems where it is buggy.
* The `asyncio` library is used instead of `subprocess` to allow immediate execution, with `async` functions to record the output.