### PR TITLE
Fix-direct-tasks

### DIFF
--- a/src/nxrefine/nxserver.py
+++ b/src/nxrefine/nxserver.py
@@ -6,8 +6,8 @@
 # The full license is in the file COPYING, distributed with this software.
 # -----------------------------------------------------------------------------
 
-import asyncio
 import os
+import subprocess
 import tempfile
 import time
 from configparser import ConfigParser
@@ -152,25 +152,20 @@ class NXTask:
                            f"-N {cpu} -hold_jid {cpu} -S /bin/bash {command}")
         return command
 
-    async def execute(self, cpu, cpu_log):        
+    def execute(self, cpu, cpu_log):        
         with open(cpu_log, 'a') as f:
             f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ' ' +
                     self.command + '\n')
-        process = await asyncio.create_subprocess_shell(
-            self.executable_command(cpu, cpu_log),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-        stdout, stderr = await process.communicate()
-        if stdout:
+        process = subprocess.run(self.executable_command(cpu, cpu_log),
+                                 shell=True,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        if process.stdout:
             with open(cpu_log, 'a') as f:
-                f.write('[stdout]\n' + stdout.decode() + '\n')
-        if stderr:
+                f.write('[stdout]\n' + process.stdout.decode() + '\n')
+        if process.stderr:
             with open(cpu_log, 'a') as f:
-                f.write('[stderr]\n' + stderr.decode() + '\n')
-
-    def run(self, cpu, cpu_log):
-        with NXLock(cpu_log, timeout=300):
-            asyncio.run(self.execute(cpu, cpu_log))
+                f.write('[stderr]\n' + process.stderr.decode() + '\n')
         if self.script and self.script.exists():
             self.script.unlink()
 
@@ -219,6 +214,8 @@ class NXServer(NXDaemon):
             self.directory = self.settings.directory
             self.save_directory()
         if server_type:
+            if server_type == 'None' or server_type == 'none':
+                server_type = None
             self.server_type = server_type
             self.settings.set('server', 'type', server_type)
             self.settings.save()

--- a/src/nxrefine/nxserver.py
+++ b/src/nxrefine/nxserver.py
@@ -109,7 +109,8 @@ class NXWorker(Thread):
                 break
             else:
                 self.log(f"{self.cpu}: Executing '{next_task.command}'")
-                next_task.run(self.cpu, self.cpu_log)
+                with NXLock(self.cpu_log, timeout=3600, expiry=3600):
+                    next_task.execute(self.cpu, self.cpu_log)
             self.worker_queue.task_done()
             self.log(f"{self.cpu}: Finished '{next_task.command}'")
         return

--- a/src/nxrefine/nxserver.py
+++ b/src/nxrefine/nxserver.py
@@ -367,6 +367,7 @@ class NXServer(NXDaemon):
         worker = NXWorker(cpu, worker_queue, self.server_log)
         worker.start()
         worker_queue.put(NXTask(task, self))
+        worker_queue.put(None)
         
     def queued_tasks(self):
         """List tasks remaining on the server queue."""

--- a/src/nxrefine/plugins/server/manage_workflows.py
+++ b/src/nxrefine/plugins/server/manage_workflows.py
@@ -634,7 +634,7 @@ class WorkflowDialog(NXDialog):
         patterns = ['nxcombine', 'nxcopy', 'nxfind', 'nxlink', 'nxload',
                     'nxmax', 'nxpdf', 'nxprepare', 'nxreduce', 'nxrefine',
                     'nxsum', 'nxtransform']
-        if self.server.server_type == 'multicore':
+        if self.server.server_type == 'multicore' or self.server_type == None:
             command = f"ps -auxww | grep -e {' -e '.join(patterns)}"
         else:
             command = "pdsh -w {} 'ps -f' | grep -e {}".format(

--- a/src/nxrefine/scripts/nxserver.py
+++ b/src/nxrefine/scripts/nxserver.py
@@ -20,7 +20,7 @@ def main():
     parser.add_argument('-d', '--directory', nargs='?', const='.',
                         help='Start the server in this directory')
     parser.add_argument('-t', '--type',
-                        help='Server type: multicore|multinode')
+                        help='Server type: multicore|multinode|none')
     parser.add_argument('-n', '--nodes', default=[], nargs='+',
                         help='Add nodes')
     parser.add_argument('-c', '--cores', help='Number of cores')


### PR DESCRIPTION
* Reverts to using the `subprocess` module, instead of `asyncio`, since there is no time-saving.
* Ensures that worker threads created for running tasks directly are terminated properly.
* Ensures that the server type can be set to None with the `nxserver` script.
* Update Manage Workflows and Manage Servers dialog