### PR TITLE
Use file locking on log files to prevent simultaneous writes

### DIFF
--- a/src/nxrefine/nxbeamline.py
+++ b/src/nxrefine/nxbeamline.py
@@ -192,10 +192,10 @@ class Sector6Beamline(NXBeamLine):
             logs = NXcollection()
         else:
             if not head_file.exists():
-                self.logger.info(
+                self.reduce.log(
                     f"'{self.entry.nxname}_head.txt' does not exist")
             if not meta_file.exists():
-                self.logger.info(
+                self.reduce.log(
                     f"'{self.entry.nxname}_meta.txt' does not exist")
             raise NeXusError('Metadata files not available')
         with open(head_file) as f:
@@ -306,7 +306,7 @@ class Sector6Beamline(NXBeamLine):
                 filter_size = monitor_signal.size
             return savgol_filter(monitor_signal, filter_size, 2)
         except Exception as error:
-            self.reduce.logger.info(f"Cannot identify monitor {self.monitor}")
+            self.reduce.log(f"Cannot identify monitor {self.monitor}")
             return np.ones(shape=(self.reduce.nframes), dtype=float)
 
 

--- a/src/nxrefine/nxserver.py
+++ b/src/nxrefine/nxserver.py
@@ -133,9 +133,10 @@ class NXController(Thread):
         return [log_file for log_file in log_files if log_file.exists()]
 
     def log(self, message):
-        with open(self.server_log, 'a') as f:
-            f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ' ' +
-                    str(message) + '\n')
+        with NXLock(self.server_log, timeout=60, expiry=60):
+            with open(self.server_log, 'a') as f:
+                f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ' ' +
+                        str(message) + '\n')
 
 
 class NXWorker(Thread):
@@ -170,8 +171,9 @@ class NXWorker(Thread):
         return
 
     def log(self, message):
-        with open(self.server_log, 'a') as f:
-            f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ' ' +
+        with NXLock(self.server_log, timeout=60, expiry=60):
+            with open(self.server_log, 'a') as f:
+                f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ' ' +
                     str(message) + '\n')
 
 
@@ -339,9 +341,10 @@ class NXServer(NXDaemon):
         self.cpus = ['cpu'+str(cpu) for cpu in range(1, cpu_count+1)]
 
     def log(self, message):
-        with open(self.server_log, 'a') as f:
-            f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ' ' +
-                    str(message) + '\n')
+        with NXLock(self.server_log, timeout=60, expiry=60):
+            with open(self.server_log, 'a') as f:
+                f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ' ' +
+                        str(message) + '\n')
 
     def run(self):
         """

--- a/src/nxrefine/plugins/refine/refine_lattice.py
+++ b/src/nxrefine/plugins/refine/refine_lattice.py
@@ -215,7 +215,7 @@ class RefineLatticeDialog(NXDialog):
         self.reduce.record('nxrefine', polar_max=self.reduce.polar_max,
                            hkl_tolerance=self.reduce.hkl_tolerance,
                            fit_report='\n'.join(self.fit_report))
-        self.reduce.logger.info('Orientation refined in NeXpy')
+        self.reduce.log('Orientation refined in NeXpy')
         self.reduce.record_end('nxrefine')
         root = self.entry.nxroot
         entries = [entry for entry in root.entries


### PR DESCRIPTION
* Creates a new NXReduce log function to wrap calls to logger.info in a NXLock context manager.
* Creates a new NXReduce server_settings dictionary to read directly from the settings rather than launching a new NXServer.