### PR TITLE
Shutdown-tracker

### DIFF
--- a/src/nxrefine/nxutils.py
+++ b/src/nxrefine/nxutils.py
@@ -6,7 +6,7 @@
 # The full license is in the file COPYING, distributed with this software.
 # -----------------------------------------------------------------------------
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from multiprocessing import get_context
+from multiprocessing import get_context, resource_tracker
 
 import numpy as np
 from nexusformat.nexus import (NeXusError, NXdata, NXentry, NXfield, NXlog,
@@ -691,3 +691,8 @@ class NXExecutor(ProcessPoolExecutor):
 
     def __repr__(self):
         return f"NXExecutor(max_workers={self._max_workers})"
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.shutdown(wait=True)
+        resource_tracker._resource_tracker._stop()
+        return False

--- a/src/nxrefine/plugins/server/manage_server.py
+++ b/src/nxrefine/plugins/server/manage_server.py
@@ -171,11 +171,11 @@ class ServerDialog(NXDialog):
         patterns = ['nxcombine', 'nxcopy', 'nxfind', 'nxlink', 'nxmax',
                     'nxpdf', 'nxprepare', 'nxreduce', 'nxrefine', 'nxsum',
                     'nxtransform']
-        if self.server_type == 'multicore' or self.server_type is None :
-            command = f"ps auxww | grep -e {' -e '.join(patterns)}"
-        else:
+        if self.server.run_command.startswith('pdsh'):
             command = "pdsh -w {} 'ps -f' | grep -e {}".format(
                 ",".join(self.server.cpus), " -e ".join(patterns))
+        elif self.server_type == 'multicore' or self.server_type is None :
+            command = f"ps auxww | grep -e {' -e '.join(patterns)}"
         process = subprocess.run(command, shell=True, stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         if process.returncode == 0:


### PR DESCRIPTION
* Shuts down the resource tracker process when a ProcessPoolExecutor is shut down.
* Ensures 'pdsh' is only invoked to monitor processes when it is used in the run command.