### PR TITLE
Replace CCTBX dependency with GEMMI dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Python Packages
 The following packages are listed as dependencies.
 
 * [nexpy](https://github.com/nexpy/nexpy/)
-* [cctbx-base](https://cci.lbl.gov/cctbx_docs/)
+* [gemmi](https://project-gemmi.github.io/)
 * [pyfai](https://pyfai.readthedocs.io/)
 * [sqlalchemy](https://docs.sqlalchemy.org/)
 * [psutil](https://psutil.readthedocs.io/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ keywords = [
 requires-python = ">=3.8"
 dependencies = [
     "nexpy >= 2.0.0b4",
+    "gemmi",
     "pyfai",
     "julia",
     "persist-queue",

--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -1043,7 +1043,7 @@ class NXRefine:
             _sg = value
         else:
             _sg = gemmi.SpaceGroup(value)
-        if _sg.is_reference_setting() == False:
+        if not _sg.is_reference_setting():
             _sg = gemmi.get_spacegroup_reference_setting(_sg.number)
         self.space_group = _sg.xhm()
         self.symmetry = _sg.crystal_system_str().lower()

--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -1029,33 +1029,33 @@ class NXRefine:
         return self.reciprocal_lattice_parameters[5]
 
     @property
-    def sgi(self):
+    def sg(self):
         """Gemmi space group information."""
         if self.space_group == '':
-            sg = self.space_groups[self.centring]
+            _sg = self.space_groups[self.centring]
         else:
-            sg = self.space_group
-        return gemmi.SpaceGroup(sg)
+            _sg = self.space_group
+        return gemmi.SpaceGroup(_sg)
 
-    @sgi.setter
-    def sgi(self, value):
+    @sg.setter
+    def sg(self, value):
         if isinstance(value, gemmi.SpaceGroup):
-            _sgi = value
+            _sg = value
         else:
-            _sgi = gemmi.SpaceGroup(value)
-        if _sgi.is_reference_setting() == False:
-            _sgi = gemmi.get_spacegroup_reference_setting(_sgi.number)
-        self.space_group = _sgi.xhm()
-        self.symmetry = _sgi.crystal_system_str().lower()
-        self.laue_group = _sgi.laue_str()
-        self.centring = _sgi.centring_type()
+            _sg = gemmi.SpaceGroup(value)
+        if _sg.is_reference_setting() == False:
+            _sg = gemmi.get_spacegroup_reference_setting(_sg.number)
+        self.space_group = _sg.xhm()
+        self.symmetry = _sg.crystal_system_str().lower()
+        self.laue_group = _sg.laue_str()
+        self.centring = _sg.centring_type()
 
     @property
     def miller(self):
         """Set of allowed Miller indices."""
         indices = gemmi.make_miller_array(
             cell=self.unit_cell,
-            spacegroup=self.sgi,
+            spacegroup=self.sg,
             dmin=self.wavelength / (2 * np.sin(self.polar_max * radians / 2)),
         )
         return indices[np.argsort(
@@ -1075,7 +1075,7 @@ class NXRefine:
 
     def indices_hkl(self, H, K, L):
         """Return the symmetry-equivalent HKL indices."""
-        ops = self.sgi.operations()
+        ops = self.sg.operations()
         _indices = sorted(
             list(set([tuple(op.apply_to_hkl((H, K, L)))
                       for op in ops.sym_ops])),
@@ -1273,7 +1273,7 @@ class NXRefine:
 
     def absent(self, H, K, L):
         """Return True if the HKL indices are systematically absent."""
-        return self.sgi.operations().is_systematically_absent(
+        return self.sg.operations().is_systematically_absent(
             (int(H), int(K), int(L)))
 
     @property

--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -82,7 +82,7 @@ class NXRefine:
     frame of coordinates to the crystal's reciprocal lattice.
 
     Functions are provided to derive nominal Bragg peak indices and two-theta
-    angles for the defined space group using Gemmi, to define the orientation
+    angles for the defined space group using GEMMI, to define the orientation
     matrix using the Busing and Levy method, and to refine the matrix and
     experimental parameters using the measured Bragg peak positions. Parameters
     are updated in the NeXus file and a settings file is created to be used in
@@ -995,7 +995,7 @@ class NXRefine:
 
     @property
     def unit_cell(self):
-        """Gemmi unit cell."""
+        """GEMMI unit cell."""
         return gemmi.UnitCell(*self.lattice_parameters)
 
     @property
@@ -1030,7 +1030,7 @@ class NXRefine:
 
     @property
     def sg(self):
-        """Gemmi space group information."""
+        """GEMMI space group information."""
         if self.space_group == '':
             _sg = self.space_groups[self.centring]
         else:

--- a/src/nxrefine/plugins/refine/define_lattice.py
+++ b/src/nxrefine/plugins/refine/define_lattice.py
@@ -106,21 +106,21 @@ class LatticeDialog(NXDialog):
             self.refine.beta = value(cif_block.find_pair('_cell_angle_beta')[1])
             self.refine.gamma = value(cif_block.find_pair('_cell_angle_gamma')[1])
             if (cif_pair := cif_block.find_pair('_space_group_IT_number')):
-                self.refine.sgi = gemmi.SpaceGroup(cif_pair[1])
+                self.refine.sg = gemmi.SpaceGroup(cif_pair[1])
             elif (cif_pair := cif_block.find_pair('_symmetry_Int_Tables_number')):
-                self.refine.sgi = gemmi.SpaceGroup(cif_pair[1])
+                self.refine.sg = gemmi.SpaceGroup(cif_pair[1])
             elif (cif_pair := cif_block.find_pair('_space_group_name_H-M_alt')):
-                self.refine.sgi = gemmi.SpaceGroup(cif_pair[1])
+                self.refine.sg = gemmi.SpaceGroup(cif_pair[1])
             elif (cif_pair := cif_block.find_pair('_symmetry_space_group_name_H-M')):
-                self.refine.sgi = gemmi.SpaceGroup(cif_pair[1])
+                self.refine.sg = gemmi.SpaceGroup(cif_pair[1])
             # NOTE: "Different Hall symbols can be used to encode the same
             # symmetry operations. ... That’s why we compare operations not
             # symbols."
             # From: https://gemmi.readthedocs.io/en/latest/symmetry.html
             elif (cif_pair := cif_block.find_pair('_space_group_name_Hall')):
-                self.refine.sgi = gemmi.find_spacegroup_by_ops(gemmi.symops_from_hall(cif_pair[1]))
+                self.refine.sg = gemmi.find_spacegroup_by_ops(gemmi.symops_from_hall(cif_pair[1]))
             elif (cif_pair := cif_block.find_pair('_symmetry_space_group_name_Hall')):
-                self.refine.sgi = gemmi.find_spacegroup_by_ops(gemmi.symops_from_hall(cif_pair[1]))
+                self.refine.sg = gemmi.find_spacegroup_by_ops(gemmi.symops_from_hall(cif_pair[1]))
             self.update_parameters()
 
     def update_parameters(self):
@@ -141,14 +141,14 @@ class LatticeDialog(NXDialog):
         if self.space_group:
             try:
                 if isinstance(self.space_group, float):
-                    sgi = gemmi.SpaceGroup(int(self.space_group))
+                    sg = gemmi.SpaceGroup(int(self.space_group))
                 else:
-                    sgi = gemmi.SpaceGroup(self.space_group)
+                    sg = gemmi.SpaceGroup(self.space_group)
             except RuntimeError as error:
                 report_error("Defining Lattice", error)
                 return
             try:
-                self.refine.sgi = sgi
+                self.refine.sg = sg
                 self.update_parameters()
             except Exception:
                 pass

--- a/src/nxrefine/plugins/refine/define_lattice.py
+++ b/src/nxrefine/plugins/refine/define_lattice.py
@@ -37,7 +37,7 @@ class LatticeDialog(NXDialog):
         self.set_title('Defining Lattice')
 
     def choose_entry(self):
-        from cctbx import sgtbx
+        import gemmi.cif
         self.refine = NXRefine(self.root['entry'])
         if self.layout.count() == 2:
             self.parameters = GridParameters()
@@ -70,22 +70,27 @@ class LatticeDialog(NXDialog):
             self.parameters['symmetry'].value = self.refine.symmetry
             self.parameters['centring'].value = self.refine.centring
             self.insert_layout(1, self.parameters.grid(header=False))
-            if sgtbx:
+            if gemmi.cif:
                 self.insert_layout(2, self.make_layout(self.import_button,
                                                        self.import_checkbox,
                                                        align='center'))
         self.update_parameters()
 
     def import_cif(self):
-        import iotbx.cif as cif
-        from cctbx import sgtbx
+        import gemmi
+        import gemmi.cif as cif
         filename = getOpenFileName(self, 'Open CIF File')
         if os.path.exists(filename):
-            cif_info = cif.reader(file_path=filename).model()
-            for c in cif_info:
-                s = cif_info[c]
-                if '_cell_length_a' in s:
+            cif_doc = cif.read_file(filename)
+            found_block = False
+            for cif_block in cif_doc:
+                if cif_block.find_pair('_cell_length_a'):
+                    found_block = True
                     break
+
+            if not found_block:
+                # TODO: Should this use report_error()?
+                raise ValueError(f"No valid lattice data found in {filename}")
 
             def value(text):
                 if '(' in text:
@@ -94,34 +99,28 @@ class LatticeDialog(NXDialog):
                     return float(text)
 
             if self.import_checkbox.isChecked():
-                self.refine.a = value(s['_cell_length_a'])
-                self.refine.b = value(s['_cell_length_b'])
-                self.refine.c = value(s['_cell_length_c'])
-            self.refine.alpha = value(s['_cell_angle_alpha'])
-            self.refine.beta = value(s['_cell_angle_beta'])
-            self.refine.gamma = value(s['_cell_angle_gamma'])
-            if '_space_group_IT_number' in s:
-                sgi = sgtbx.space_group_info(s['_space_group_IT_number'])
-            elif '_symmetry_Int_Tables_number' in s:
-                sgi = sgtbx.space_group_info(s['_symmetry_Int_Tables_number'])
-            elif '_space_group_name_H-M_alt' in s:
-                sgi = sgtbx.space_group_info(s['_space_group_name_H-M_alt'])
-            elif '_symmetry_space_group_name_H-M' in s:
-                sgi = sgtbx.space_group_info(
-                    s['_symmetry_space_group_name_H-M'])
-            elif '_space_group_name_Hall' in s:
-                sgi = sgtbx.space_group_info(
-                    'hall: '+s['_space_group_name_Hall'])
-            elif '_symmetry_space_group_name_Hall' in s:
-                sgi = sgtbx.space_group_info(
-                    'hall: '+s['_symmetry_space_group_name_Hall'])
-            else:
-                sgi = None
-            if sgi:
-                self.refine.space_group = sgi.type().lookup_symbol()
-                self.refine.symmetry = sgi.group().crystal_system().lower()
-                self.refine.laue_group = sgi.group().laue_group_type()
-                self.refine.centring = self.refine.space_group[0]
+                self.refine.a = value(cif_block.find_pair('_cell_length_a')[1])
+                self.refine.b = value(cif_block.find_pair('_cell_length_b')[1])
+                self.refine.c = value(cif_block.find_pair('_cell_length_c')[1])
+            self.refine.alpha = value(cif_block.find_pair('_cell_angle_alpha')[1])
+            self.refine.beta = value(cif_block.find_pair('_cell_angle_beta')[1])
+            self.refine.gamma = value(cif_block.find_pair('_cell_angle_gamma')[1])
+            if (cif_pair := cif_block.find_pair('_space_group_IT_number')):
+                self.refine.sgi = gemmi.SpaceGroup(cif_pair[1])
+            elif (cif_pair := cif_block.find_pair('_symmetry_Int_Tables_number')):
+                self.refine.sgi = gemmi.SpaceGroup(cif_pair[1])
+            elif (cif_pair := cif_block.find_pair('_space_group_name_H-M_alt')):
+                self.refine.sgi = gemmi.SpaceGroup(cif_pair[1])
+            elif (cif_pair := cif_block.find_pair('_symmetry_space_group_name_H-M')):
+                self.refine.sgi = gemmi.SpaceGroup(cif_pair[1])
+            # NOTE: "Different Hall symbols can be used to encode the same
+            # symmetry operations. ... That’s why we compare operations not
+            # symbols."
+            # From: https://gemmi.readthedocs.io/en/latest/symmetry.html
+            elif (cif_pair := cif_block.find_pair('_space_group_name_Hall')):
+                self.refine.sgi = gemmi.find_spacegroup_by_ops(gemmi.symops_from_hall(cif_pair[1]))
+            elif (cif_pair := cif_block.find_pair('_symmetry_space_group_name_Hall')):
+                self.refine.sgi = gemmi.find_spacegroup_by_ops(gemmi.symops_from_hall(cif_pair[1]))
             self.update_parameters()
 
     def update_parameters(self):
@@ -138,21 +137,18 @@ class LatticeDialog(NXDialog):
         self.parameters['gamma'].value = self.refine.gamma
 
     def set_groups(self):
-        from cctbx import sgtbx
+        import gemmi
         if self.space_group:
             try:
                 if isinstance(self.space_group, float):
-                    sgi = sgtbx.space_group_info(int(self.space_group))
+                    sgi = gemmi.SpaceGroup(int(self.space_group))
                 else:
-                    sgi = sgtbx.space_group_info(self.space_group)
+                    sgi = gemmi.SpaceGroup(self.space_group)
             except RuntimeError as error:
                 report_error("Defining Lattice", error)
                 return
             try:
-                self.refine.space_group = sgi.type().lookup_symbol()
-                self.refine.symmetry = sgi.group().crystal_system().lower()
-                self.refine.laue_group = sgi.group().laue_group_type()
-                self.refine.centring = self.refine.space_group[0]
+                self.refine.sgi = sgi
                 self.update_parameters()
             except Exception:
                 pass


### PR DESCRIPTION
This replaces the dependency on [CCTBX](https://cctbx.github.io/) with [GEMMI](https://gemmi.readthedocs.io/en/latest/). This makes nxrefine installable using pip, uv, etc.

The only user-noticable changes should be:

- The string representation of a space group stored in `NXRefine.space_group` no longer has a space between the space group symbol and the setting number (when there are multiple settings). E.g., `F d -3 m :2` has changed to `F d -3 m:2`. This should have no backwards-compatibility implications, since both CCTBX and GEMMI can parse both string formats.
- The list of Miller indices generated by `NXRefine.miller` and used by `NXRefine.two_thetas`, `NXRefine.indices`, etc. are in a slightly different order. They are still sorted by decreasing d-spacing, but indices with the same d-spacing may be in a different order.